### PR TITLE
Array open is called "mark" by PostScript

### DIFF
--- a/src/operators.rs
+++ b/src/operators.rs
@@ -246,7 +246,7 @@ fn array_close(state: &mut State) -> Result<()> {
     let found = (&stack.inner)
         .iter()
         .rev()
-        .position(|item| matches!(item, Item::ArrayOpen));
+        .position(|item| matches!(item, Item::Mark));
 
     if found.is_none() {
         return Err(Report::msg("/unmatchedmark in --]--"));

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -14,7 +14,7 @@ pub enum Item {
     //Dict(()),
     Key(String),
     Block(String),
-    ArrayOpen,
+    Mark,
     Array(Vec<Item>),
 }
 


### PR DESCRIPTION
mark is the proper name for the object that gets pushed on the operand stack when a `[` is encountered